### PR TITLE
Set CI Pixi version to latest

### DIFF
--- a/.github/actions/initialize_conda_env/action.yaml
+++ b/.github/actions/initialize_conda_env/action.yaml
@@ -15,7 +15,7 @@ runs:
     - name: Setup conda env
       uses: prefix-dev/setup-pixi@v0.8.10
       with:
-        pixi-version: v0.44.0
+        pixi-version: latest
         # building cache is slower than not caching
         cache: false
 


### PR DESCRIPTION
The CI Pixi version was pinned to `v0.44.0` while the current version is `v0.69.0`. The older Pixi version doesn't support updated lockfile protocols made with newer versions of Pixi, which will cause the CI to fail if the lockfile is updated with a more recent Pixi version. I suggest that we set the Pixi version to `latest` (so that we won't have to update this manually again) or at least a newer version.