### PR TITLE
Remove CI Docker container

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -17,10 +17,8 @@ defaults:
 jobs:
   build-book:
     runs-on: ubuntu-latest
-    container: ubuntu:22.04
 
     steps:
-
       - uses: actions/checkout@v5
 
       - name: Initialize SSCP conda environment
@@ -33,8 +31,7 @@ jobs:
           key: jupyter-cache-${{ hashFiles('pixi.lock') }}
 
       - name: Run the lecture notes and build webpage
-        run:
-          pixi run jupyter-book build .
+        run: pixi run jupyter-book build .
 
       - uses: actions/upload-artifact@v6
         # always upload artifact, which can include error messages


### PR DESCRIPTION
This PR removes the redundant ubuntu:22.04 Docker container from the build-book job. Running the setup directly on the GitHub host runner removes unnecessary layers of virtualization and avoids potential Docker Hub timeout issues.